### PR TITLE
지상에 있는 '지하 및 실내 구역 입구' 핀이 숨겨지지 않도록 함

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -904,7 +904,7 @@ function drawUndergroundLayer() {
 function removeDisabledMapsPin() {
     if (!IS_VISIBLE_ACTIVE_MAPS_PIN) return;
 
-    const dataSelector = IS_UNDERGROUND_ACTIVE ? ':not([data-is-underground])' : '[data-is-underground]';
+    const dataSelector = IS_UNDERGROUND_ACTIVE ? ':not([data-is-underground])' + ':not([data-tip*="지하 및 실내 구역 입구"])' : '[data-is-underground]';
     document.querySelectorAll(`#mapsLayerPoint > .maps-point${dataSelector}`).forEach(element => element.remove());
 }
 


### PR DESCRIPTION
'지하 맵' 스위치와 '활성맵 핀' 스위치를 동시에 켰을 때 지상에 있는 '지하 및 실내 구역 입구' 핀이 숨겨져서 불편함이 있었습니다.

=> '활성맵 핀' 기능을 켜도 지상에 있는 '지하 및 실내 구역 입구' 핀은 숨겨지지 않게 합니다.